### PR TITLE
update guava from v21 to v27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     provided 'org.springframework.boot:spring-boot-starter-web:1.5.9.RELEASE'
     provided 'org.springframework.boot:spring-boot-starter-actuator:1.5.9.RELEASE'
 
-    compile 'com.google.guava:guava:21.0'
+    compile 'com.google.guava:guava:27.0-jre'
     testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.9.RELEASE'
 }
 


### PR DESCRIPTION
dependency scanning on piano projects has flagged an old version of guava as containing known vulnerabilities. this PR simply requests to update the version of guava from 21 to 27.